### PR TITLE
Fixes setEndpoint not removing trailing slashes from endpoint urls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1020,7 +1020,6 @@ Cmi5.prototype = {
     setEndpoint: function (endpoint) {
         this.log("setEndpoint: ", endpoint);
 
-        this._endpoint = endpoint;
         // Remove trailing slashes, as this library forms URLs with leading slashes in subpaths.
         this._endpoint = this._endpoint.replace(/\/+$/, "");
     },


### PR DESCRIPTION
In the released package on https://www.npmjs.com/package/@rusticisoftware/cmi5 setEndpoint is defined as `setEndpoint:function(t){this.log("setEndpoint: ",t),this._endpoint=t;}` and not `setEndpoint:function(t){this.log("setEndpoint: ",t),this._endpoint=t.replace(/\/+$/, "");}` This change fixes the minified production code.