### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
 # @rusticisoftware/cmi5
 JavaScript implementation of cmi5 AU runtime
 
-[![Build Status](https://travis-ci.org/RusticiSoftware/cmi5.js.png)](https://travis-ci.org/RusticiSoftware/cmi5.js)
-[![GitHub release](https://img.shields.io/github/release/RusticiSoftware/cmi5.js.svg?maxAge=2592000)](https://github.com/RusticiSoftware/cmi5.js/releases)
-[![npm](https://img.shields.io/npm/v/cmi5.js.svg?maxAge=2592000)](https://www.npmjs.com/package/cmi5.js)
-
-This repository does not contain build artifacts, to use a non-source version you will have to build as described below or access artifacts via the [releases page](https://github.com/RusticiSoftware/cmi5.js/releases).
-
 For hosted API documentation, basic usage instructions, etc. visit the main project website at:
 
 http://rusticisoftware.github.io/cmi5.js/
@@ -14,12 +8,3 @@ http://rusticisoftware.github.io/cmi5.js/
 For information about cmi5 visit:
 
 http://aicc.github.io/CMI-5_Spec_Current/
-
-## Building the Library
-
-The library uses Webpack for building. Install Node.js which includes `npm`. Then from the root of the repository run:
-
-    npm ci
-    npx webpack
-
-This will create `dist/cmi5.js`.


### PR DESCRIPTION
Removed the build stuff and moved it to the wiki for the repo since the README gets published to npm which is where most users should get this library. Dropped the badges because they just aren't that helpful with the given UIs these days.